### PR TITLE
test async blobstore snapshot

### DIFF
--- a/.versions.json
+++ b/.versions.json
@@ -1,5 +1,5 @@
 {
   "precog-quasar": "205.1.0",
   "precog-quasar-lib-blobstore": "3.1.0",
-  "precog-async-blobstore": "5.1.4"
+  "precog-async-blobstore": "5.1.4-a7f629d"
 }

--- a/.versions.json
+++ b/.versions.json
@@ -1,5 +1,5 @@
 {
   "precog-quasar": "205.1.0",
   "precog-quasar-lib-blobstore": "3.1.0",
-  "precog-async-blobstore": "5.1.4-a7f629d"
+  "precog-async-blobstore": "5.1.5"
 }


### PR DESCRIPTION
Update async-blobstore when https://github.com/precog/async-blobstore/pull/117 is merged.